### PR TITLE
Fixed the page title's year to current version

### DIFF
--- a/Website/index.cshtml
+++ b/Website/index.cshtml
@@ -20,7 +20,7 @@
 <html manifest="@Fingerprint("/site.appcache")" itemscope itemtype="http://schema.org/WebPage">
 <head>
 	<meta charset="utf-8" />
-	<title>Visual Studio 2013 keyboard shortcuts - complete list</title>
+	<title>Visual Studio @version keyboard shortcuts - complete list</title>
 	<link rel="icon" href="@Fingerprint("/favicon.ico")" type="image/x-icon" />
 	<meta name="description" content="A complete list of all keyboard shortcuts in Visual Studio @version" />
 	<meta name="keywords" content="shortcut, shortcuts, keybinding, key binding, vs, visual studio @version" />


### PR DESCRIPTION
The title was displaying 2013 statically before. This should fix it to dynamically use the version.